### PR TITLE
Add Minimax CPU

### DIFF
--- a/src/main/java/Board.java
+++ b/src/main/java/Board.java
@@ -48,4 +48,11 @@ public class Board {
             requestedCell.mark(player);
         }
     }
+
+    public void remove(int position) {
+        Cell requestedCell = board.get(position);
+        if (requestedCell.isOccupied()) {
+            requestedCell.unmark();
+        }
+    }
 }

--- a/src/main/java/Board.java
+++ b/src/main/java/Board.java
@@ -42,7 +42,7 @@ public class Board {
 
     int getSideLength() { return this.sideLength; }
 
-    public void addMove(int position, Player player) {
+    public void add(int position, Player player) {
         Cell requestedCell = board.get(position);
         if (requestedCell.isNotOccupied()) {
             requestedCell.mark(player);

--- a/src/main/java/Board.java
+++ b/src/main/java/Board.java
@@ -30,6 +30,16 @@ public class Board {
         return this.totalCells;
     }
 
+    public List<Integer> available() {
+        List<Integer> available = new ArrayList<>();
+        for (int i = 0; i < this.totalCells; i++) {
+            if(getCell(i).isNotOccupied()) {
+                available.add(i);
+            }
+        }
+        return available;
+    }
+
     int getSideLength() { return this.sideLength; }
 
     public void addMove(int position, Player player) {

--- a/src/main/java/Cell.java
+++ b/src/main/java/Cell.java
@@ -13,6 +13,8 @@ public class Cell {
         this.occupant = player;
     }
 
+    void unmark() { this.occupant = null; }
+
     boolean isNotOccupied() {
         return occupant == null;
     }

--- a/src/main/java/Game.java
+++ b/src/main/java/Game.java
@@ -59,7 +59,7 @@ class Game {
         display.showBoard();
         Display.outMessage(messages.announcePlayerTurn(currentPlayer()));
         int playerInput = currentPlayer().getNextMove();
-        board.addMove(playerInput, currentPlayer());
+        board.add(playerInput, currentPlayer());
     }
 
     private void processTurn() {

--- a/src/main/java/Messages.java
+++ b/src/main/java/Messages.java
@@ -11,7 +11,7 @@ public class Messages {
 
         standardMessage.put("gameOverDraw", "Bad luck! It's a draw!");
         standardMessage.put("invalidMove", "Sorry, that move is invalid.\nPlease choose an unoccupied square.");
-        standardMessage.put("setup", "Select a game mode:\n1. Human v Human\n2. Human v CPU\n3. CPU v CPU\n");
+        standardMessage.put("setup", "Select a game mode:\n1. Human v Human\n2. Human v CPU (EASY)\n3. Human v CPU (HARD)\n4. CPU v CPU");
         standardMessage.put("boardSize", "Select a board size:\n1. 3x3 (default)\n2. 4x4");
 
         formatMessage.put("gameInstructions", "Input numbers between 1-%s on alternative turns to place your mark in the %s grid.");

--- a/src/main/java/Minimax.java
+++ b/src/main/java/Minimax.java
@@ -1,0 +1,56 @@
+public class Minimax {
+    private Player maximizer;
+    private Player minimizer;
+    private Board board;
+    private Rules rules;
+
+    public Minimax(Board board, Rules rules, Player maximizer, Player minimizer) {
+        this.board = board;
+        this.rules = rules;
+        this.maximizer = maximizer;
+        this.minimizer = minimizer;
+    }
+
+    private Integer evaluateBoard() {
+        if (rules.hasWinningMove(maximizer)) {
+            return 10;
+        }
+
+        if (rules.hasWinningMove(minimizer)) {
+            return -10;
+        }
+
+        return 0;
+    }
+
+    public Integer minimax(int depth, boolean isMax) {
+        int score = evaluateBoard();
+
+        if (score == 10) {
+            return score - depth;
+        }
+
+        if (score == -10) {
+            return score + depth;
+        }
+
+        if (noMovesLeft()) {
+            return 0;
+        }
+
+        if(isMax) {
+            int best = Integer.MIN_VALUE;
+
+            return best;
+
+        } else {
+            int best = Integer.MAX_VALUE;
+
+            return best;
+        }
+    }
+
+    private boolean noMovesLeft() {
+        return rules.gameIsOver();
+    }
+}

--- a/src/main/java/Minimax.java
+++ b/src/main/java/Minimax.java
@@ -12,22 +12,22 @@ public class Minimax {
     }
 
     private Integer evaluateBoard(int depth) {
+        final int WINNING_SCORE = 10;
+        final int LOSING_SCORE = -10;
+        final int DRAW_SCORE = 0;
+
         if (rules.hasWinningMove(maximizer)) {
-            return 10 - depth;
+            return WINNING_SCORE - depth;
         }
 
         if (rules.hasWinningMove(minimizer)) {
-            return -10 + depth;
+            return LOSING_SCORE + depth;
         }
 
-        return 0;
+        return DRAW_SCORE;
     }
 
-    public Integer minimax(int depth, boolean isMax) {
-        return minimax(depth, isMax, Integer.MIN_VALUE, Integer.MAX_VALUE);
-    }
-
-    private Integer minimax(int depth, boolean isMax, int alpha, int beta) {
+    private Integer minimax(int depth, boolean isMax) {
         int score = evaluateBoard(depth);
 
         if (score != 0) {
@@ -44,13 +44,8 @@ public class Minimax {
             for (int index : board.available()) {
                 board.add(index, maximizer);
                 best = Integer.max(best,
-                        minimax(depth + 1, false, alpha, beta));
+                        minimax(depth + 1, false));
                 board.remove(index);
-
-                int updatedAlpha = Integer.max(alpha, best);
-                if (beta <= updatedAlpha) {
-                    break;
-                }
             }
 
             return best;
@@ -60,13 +55,8 @@ public class Minimax {
             for (int index : board.available()) {
                 board.add(index, minimizer);
                 best = Integer.min(best,
-                        minimax(depth + 1, true, alpha, beta));
+                        minimax(depth + 1, true));
                 board.remove(index);
-
-                int updatedBeta = Integer.min(beta, best);
-                if (updatedBeta <= alpha) {
-                    break;
-                }
             }
 
             return best;
@@ -79,7 +69,7 @@ public class Minimax {
 
         for (int index : board.available()) {
             board.add(index, maximizer);
-            int moveValue = minimax(0, false, Integer.MIN_VALUE, Integer.MAX_VALUE);
+            int moveValue = minimax(0, false);
             board.remove(index);
 
             if (moveValue > bestValue) {

--- a/src/main/java/Minimax.java
+++ b/src/main/java/Minimax.java
@@ -24,6 +24,10 @@ public class Minimax {
     }
 
     public Integer minimax(int depth, boolean isMax) {
+        return minimax(depth, isMax, Integer.MIN_VALUE, Integer.MAX_VALUE);
+    }
+
+    private Integer minimax(int depth, boolean isMax, int alpha, int beta) {
         int score = evaluateBoard();
 
         if (score == 10) {
@@ -44,8 +48,13 @@ public class Minimax {
             for (int index : board.available()) {
                 board.addMove(index, maximizer);
                 best = Integer.max(best,
-                        minimax(depth + 1, false));
+                        minimax(depth + 1, false, alpha, beta));
                 board.remove(index);
+
+                int updatedAlpha = Integer.max(alpha, best);
+                if (beta <= updatedAlpha) {
+                    break;
+                }
             }
 
             return best;
@@ -55,8 +64,13 @@ public class Minimax {
             for (int index : board.available()) {
                 board.addMove(index, minimizer);
                 best = Integer.min(best,
-                        minimax(depth + 1, true));
+                        minimax(depth + 1, true, alpha, beta));
                 board.remove(index);
+
+                int updatedBeta = Integer.min(beta, best);
+                if (updatedBeta <= alpha) {
+                    break;
+                }
             }
 
             return best;
@@ -69,7 +83,7 @@ public class Minimax {
 
         for (int index : board.available()) {
             board.addMove(index, maximizer);
-            int moveValue = minimax(0, false);
+            int moveValue = minimax(0, false, Integer.MIN_VALUE, Integer.MAX_VALUE);
             board.remove(index);
 
             if (moveValue > bestValue) {

--- a/src/main/java/Minimax.java
+++ b/src/main/java/Minimax.java
@@ -1,5 +1,3 @@
-import java.util.Collections;
-
 public class Minimax {
     private Player maximizer;
     private Player minimizer;
@@ -46,16 +44,41 @@ public class Minimax {
             for (int index : board.available()) {
                 board.addMove(index, maximizer);
                 best = Integer.max(best,
-                        minimax(depth + 1, !isMax));
+                        minimax(depth + 1, false));
+                board.remove(index);
             }
 
             return best;
-
         } else {
             int best = Integer.MAX_VALUE;
 
+            for (int index : board.available()) {
+                board.addMove(index, minimizer);
+                best = Integer.min(best,
+                        minimax(depth + 1, true));
+                board.remove(index);
+            }
+
             return best;
         }
+    }
+
+    public Integer optimal() {
+        int bestValue = Integer.MIN_VALUE;
+        int bestIndex = Integer.MIN_VALUE;
+
+        for (int index : board.available()) {
+            board.addMove(index, maximizer);
+            int moveValue = minimax(0, false);
+            board.remove(index);
+
+            if (moveValue > bestValue) {
+                bestValue = moveValue;
+                bestIndex = index;
+            }
+        }
+
+        return bestIndex;
     }
 
     private boolean noMovesLeft() {

--- a/src/main/java/Minimax.java
+++ b/src/main/java/Minimax.java
@@ -1,3 +1,5 @@
+import java.util.Collections;
+
 public class Minimax {
     private Player maximizer;
     private Player minimizer;
@@ -40,6 +42,12 @@ public class Minimax {
 
         if(isMax) {
             int best = Integer.MIN_VALUE;
+
+            for (int index : board.available()) {
+                board.addMove(index, maximizer);
+                best = Integer.max(best,
+                        minimax(depth + 1, !isMax));
+            }
 
             return best;
 

--- a/src/main/java/Minimax.java
+++ b/src/main/java/Minimax.java
@@ -11,13 +11,13 @@ public class Minimax {
         this.minimizer = minimizer;
     }
 
-    private Integer evaluateBoard() {
+    private Integer evaluateBoard(int depth) {
         if (rules.hasWinningMove(maximizer)) {
-            return 10;
+            return 10 - depth;
         }
 
         if (rules.hasWinningMove(minimizer)) {
-            return -10;
+            return -10 + depth;
         }
 
         return 0;
@@ -28,14 +28,10 @@ public class Minimax {
     }
 
     private Integer minimax(int depth, boolean isMax, int alpha, int beta) {
-        int score = evaluateBoard();
+        int score = evaluateBoard(depth);
 
-        if (score == 10) {
-            return score - depth;
-        }
-
-        if (score == -10) {
-            return score + depth;
+        if (score != 0) {
+            return score;
         }
 
         if (noMovesLeft()) {
@@ -46,7 +42,7 @@ public class Minimax {
             int best = Integer.MIN_VALUE;
 
             for (int index : board.available()) {
-                board.addMove(index, maximizer);
+                board.add(index, maximizer);
                 best = Integer.max(best,
                         minimax(depth + 1, false, alpha, beta));
                 board.remove(index);
@@ -62,7 +58,7 @@ public class Minimax {
             int best = Integer.MAX_VALUE;
 
             for (int index : board.available()) {
-                board.addMove(index, minimizer);
+                board.add(index, minimizer);
                 best = Integer.min(best,
                         minimax(depth + 1, true, alpha, beta));
                 board.remove(index);
@@ -82,7 +78,7 @@ public class Minimax {
         int bestIndex = Integer.MIN_VALUE;
 
         for (int index : board.available()) {
-            board.addMove(index, maximizer);
+            board.add(index, maximizer);
             int moveValue = minimax(0, false, Integer.MIN_VALUE, Integer.MAX_VALUE);
             board.remove(index);
 

--- a/src/main/java/Minimax.java
+++ b/src/main/java/Minimax.java
@@ -38,7 +38,7 @@ public class Minimax {
             return 0;
         }
 
-        if(isMax) {
+        if (isMax) {
             int best = Integer.MIN_VALUE;
 
             for (int index : board.available()) {

--- a/src/main/java/PlayerCPU.java
+++ b/src/main/java/PlayerCPU.java
@@ -1,12 +1,12 @@
+import java.util.List;
+
 public class PlayerCPU implements Player {
     private String symbol;
-    private Rules rules;
-    private int totalCells;
+    private Board board;
 
-    PlayerCPU(String symbol, Rules rules, Board board) {
+    PlayerCPU(String symbol, Board board) {
         this.symbol = symbol;
-        this.rules = rules;
-        this.totalCells = board.getTotalCells();
+        this.board = board;
     }
 
     @Override
@@ -16,17 +16,14 @@ public class PlayerCPU implements Player {
 
     @Override
     public int getNextMove() {
-        int desiredCell;
-        do {
-            desiredCell = pickRandomCell();
-        } while (rules.isNotValidMove(desiredCell));
-
         oneSecondSleep();
-        return desiredCell;
+        return pickRandomCell();
     }
 
     private int pickRandomCell() {
-        return (int)Math.floor(Math.random() * totalCells);
+        List<Integer> available = board.available();
+        int cellIndex = (int)Math.floor(Math.random() * available.size());
+        return available.get(cellIndex);
     }
 
     private void oneSecondSleep() {

--- a/src/main/java/PlayerMinimax.java
+++ b/src/main/java/PlayerMinimax.java
@@ -1,0 +1,29 @@
+public class PlayerMinimax implements Player {
+    private String symbol;
+    private Minimax minimax;
+
+
+    PlayerMinimax(String symbol, Rules rules, Board board, Player opponent) {
+        this.symbol = symbol;
+        minimax = new Minimax(board, rules, this, opponent);
+    }
+
+    @Override
+    public String getSymbol() {
+        return symbol;
+    }
+
+    @Override
+    public int getNextMove() {
+        oneSecondSleep();
+        return minimax.optimal();
+    }
+
+    private void oneSecondSleep() {
+        try {
+            Thread.sleep(1000);
+        } catch(InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/Players.java
+++ b/src/main/java/Players.java
@@ -10,6 +10,7 @@ public class Players {
         int modeNumber = input.nextInt();
         switch(modeNumber) {
             case 1:
+            default:
                 this.playerCross = new PlayerHuman("X", rules);
                 this.playerNought = new PlayerHuman("O", rules);
                 break;
@@ -18,12 +19,13 @@ public class Players {
                 this.playerNought = new PlayerCPU("O", board);
                 break;
             case 3:
+                this.playerCross = new PlayerHuman("X", rules);
+                this.playerNought = new PlayerMinimax("O", rules, board, playerCross);
+                break;
+            case 4:
                 this.playerCross = new PlayerCPU("X", board);
                 this.playerNought = new PlayerCPU("O", board);
                 break;
-            case 4:
-                this.playerCross = new PlayerHuman("X", rules);
-                this.playerNought = new PlayerMinimax("O", rules, board, playerCross);
         }
         this.currentPlayer = playerCross;
     }

--- a/src/main/java/Players.java
+++ b/src/main/java/Players.java
@@ -15,11 +15,11 @@ public class Players {
                 break;
             case 2:
                 this.playerCross = new PlayerHuman("X", rules);
-                this.playerNought = new PlayerCPU("O", rules, board);
+                this.playerNought = new PlayerCPU("O", board);
                 break;
             case 3:
-                this.playerCross = new PlayerCPU("X", rules, board);
-                this.playerNought = new PlayerCPU("O", rules, board);
+                this.playerCross = new PlayerCPU("X", board);
+                this.playerNought = new PlayerCPU("O", board);
                 break;
             case 4:
                 this.playerCross = new PlayerHuman("X", rules);

--- a/src/main/java/Players.java
+++ b/src/main/java/Players.java
@@ -21,6 +21,9 @@ public class Players {
                 this.playerCross = new PlayerCPU("X", rules, board);
                 this.playerNought = new PlayerCPU("O", rules, board);
                 break;
+            case 4:
+                this.playerCross = new PlayerHuman("X", rules);
+                this.playerNought = new PlayerMinimax("O", rules, board, playerCross);
         }
         this.currentPlayer = playerCross;
     }

--- a/src/test/java/BoardTest.java
+++ b/src/test/java/BoardTest.java
@@ -152,4 +152,11 @@ public class BoardTest {
         List<Integer> expected = new ArrayList<>(Arrays.asList(5,6,7,8));
         assertEquals(expected, result);
     }
+
+    @Test
+    public void boardCanBeUnmarked() {
+        board.addMove(0, playerCross);
+        board.remove(0);
+        assertEquals(9, board.available().size());
+    }
 }

--- a/src/test/java/BoardTest.java
+++ b/src/test/java/BoardTest.java
@@ -51,7 +51,7 @@ public class BoardTest {
 
     @Test
     public void cellZeroShouldBeCrossWhenAddedToBoard() {
-        board.addMove(0, playerCross);
+        board.add(0, playerCross);
         String cellOccupant = board.getCell(0).getOccupant();
         assertEquals("X", cellOccupant);
     }
@@ -82,7 +82,7 @@ public class BoardTest {
 
     @Test
     public void UpdatedBoardShouldReturnCorrectBoardStateAfterOneMove() {
-        board.addMove(0, playerCross);
+        board.add(0, playerCross);
         String[] updatedBoard = createStringArrayFromBoard(board);
         String[] expectedBoard = {
                 "X", " ", " ",
@@ -94,8 +94,8 @@ public class BoardTest {
 
     @Test
     public void UpdatedBoardShouldReturnCorrectBoardStateAfterTwoMoves() {
-        board.addMove(0, playerCross);
-        board.addMove(4, playerCross);
+        board.add(0, playerCross);
+        board.add(4, playerCross);
         String[] updatedBoard = createStringArrayFromBoard(board);
         String[] expectedBoard = {
                 "X", " ", " ",
@@ -107,8 +107,8 @@ public class BoardTest {
 
     @Test
     public void UpdatedBoardShouldNotAllowOverwritingCells() {
-        board.addMove(1, playerNought);
-        board.addMove(1, playerCross);
+        board.add(1, playerNought);
+        board.add(1, playerCross);
         String[] updatedBoard = createStringArrayFromBoard(board);
         String[] expectedBoard = {
                 " ", "O", " ",
@@ -120,13 +120,13 @@ public class BoardTest {
 
     @Test
     public void UpdateBoardShouldBeAbleToRunEntireGame() {
-        board.addMove(4, playerCross);
-        board.addMove(2, playerNought);
-        board.addMove(3, playerCross);
-        board.addMove(5, playerNought);
-        board.addMove(0, playerCross);
-        board.addMove(8, playerNought);
-        board.addMove(4, playerCross);
+        board.add(4, playerCross);
+        board.add(2, playerNought);
+        board.add(3, playerCross);
+        board.add(5, playerNought);
+        board.add(0, playerCross);
+        board.add(8, playerNought);
+        board.add(4, playerCross);
         String[] updatedBoard = createStringArrayFromBoard(board);
         String[] expectedBoard = {
                 "X", " ", "O",
@@ -143,11 +143,11 @@ public class BoardTest {
 
     @Test
     public void halfFullBoardReturnsIndexesAvailable() {
-        board.addMove(0, playerCross);
-        board.addMove(1, playerNought);
-        board.addMove(2, playerCross);
-        board.addMove(3, playerNought);
-        board.addMove(4, playerCross);
+        board.add(0, playerCross);
+        board.add(1, playerNought);
+        board.add(2, playerCross);
+        board.add(3, playerNought);
+        board.add(4, playerCross);
         List<Integer> result = board.available();
         List<Integer> expected = new ArrayList<>(Arrays.asList(5,6,7,8));
         assertEquals(expected, result);
@@ -155,7 +155,7 @@ public class BoardTest {
 
     @Test
     public void boardCanBeUnmarked() {
-        board.addMove(0, playerCross);
+        board.add(0, playerCross);
         board.remove(0);
         assertEquals(9, board.available().size());
     }

--- a/src/test/java/BoardTest.java
+++ b/src/test/java/BoardTest.java
@@ -2,6 +2,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -135,6 +137,19 @@ public class BoardTest {
     }
 
     @Test
-    public void name() {
+    public void emptyBoardReturnsNineAvailableCells() {
+        assertEquals(9, board.available().size());
+    }
+
+    @Test
+    public void halfFullBoardReturnsIndexesAvailable() {
+        board.addMove(0, playerCross);
+        board.addMove(1, playerNought);
+        board.addMove(2, playerCross);
+        board.addMove(3, playerNought);
+        board.addMove(4, playerCross);
+        List<Integer> result = board.available();
+        List<Integer> expected = new ArrayList<>(Arrays.asList(5,6,7,8));
+        assertEquals(expected, result);
     }
 }

--- a/src/test/java/DisplayTest.java
+++ b/src/test/java/DisplayTest.java
@@ -54,15 +54,15 @@ public class DisplayTest {
         Display display = new Display(board);
         Player playerCross = new PlayerHuman("X");
         Player playerNought = new PlayerHuman("O");
-        board.addMove(0, playerCross);
-        board.addMove(2, playerCross);
-        board.addMove(4, playerCross);
-        board.addMove(6, playerCross);
-        board.addMove(8, playerCross);
-        board.addMove(1, playerNought);
-        board.addMove(3, playerNought);
-        board.addMove(5, playerNought);
-        board.addMove(7, playerNought);
+        board.add(0, playerCross);
+        board.add(2, playerCross);
+        board.add(4, playerCross);
+        board.add(6, playerCross);
+        board.add(8, playerCross);
+        board.add(1, playerNought);
+        board.add(3, playerNought);
+        board.add(5, playerNought);
+        board.add(7, playerNought);
         display.showBoard();
         assertEquals(boardOutput, outContent.toString());
     }

--- a/src/test/java/MinimaxTest.java
+++ b/src/test/java/MinimaxTest.java
@@ -21,61 +21,61 @@ public class MinimaxTest {
 
     @Test
     public void WinStateReturns10() {
-        board.addMove(0, playerMaxi);
-        board.addMove(1, playerMaxi);
-        board.addMove(2, playerMaxi);
+        board.add(0, playerMaxi);
+        board.add(1, playerMaxi);
+        board.add(2, playerMaxi);
         int result = minimax.minimax(0, false);
         assertEquals(10, result);
     }
 
     @Test
     public void LossStateReturnsMinus10() {
-        board.addMove(0, playerMini);
-        board.addMove(1, playerMini);
-        board.addMove(2, playerMini);
+        board.add(0, playerMini);
+        board.add(1, playerMini);
+        board.add(2, playerMini);
         int result = minimax.minimax(0, false);
         assertEquals(-10, result);
     }
 
     @Test
     public void DrawReturnsZero() {
-        board.addMove(0, playerMini);
-        board.addMove(1, playerMaxi);
-        board.addMove(2, playerMini);
-        board.addMove(3, playerMaxi);
-        board.addMove(4, playerMaxi);
-        board.addMove(5, playerMini);
-        board.addMove(6, playerMaxi);
-        board.addMove(7, playerMini);
-        board.addMove(8, playerMaxi);
+        board.add(0, playerMini);
+        board.add(1, playerMaxi);
+        board.add(2, playerMini);
+        board.add(3, playerMaxi);
+        board.add(4, playerMaxi);
+        board.add(5, playerMini);
+        board.add(6, playerMaxi);
+        board.add(7, playerMini);
+        board.add(8, playerMaxi);
         int result = minimax.minimax(0, false);
         assertEquals(0, result);
     }
 
     @Test
     public void minimaxPlaysForWin() {
-        board.addMove(0, playerMaxi);
-        board.addMove(1, playerMaxi);
+        board.add(0, playerMaxi);
+        board.add(1, playerMaxi);
         int result = minimax.optimal();
         assertEquals(2, result);
     }
 
     @Test
     public void minimaxBlocksOpponentWin() {
-        board.addMove(3, playerMini);
-        board.addMove(4, playerMini);
+        board.add(3, playerMini);
+        board.add(4, playerMini);
         int result = minimax.optimal();
         assertEquals(5, result);
     }
 
     @Test
     public void minimaxGoesForEarliestWin() {
-        board.addMove(0, playerMini);
-        board.addMove(1, playerMini);
-        board.addMove(2, playerMaxi);
-        board.addMove(3, playerMini);
-        board.addMove(4, playerMaxi);
-        board.addMove(5, playerMaxi);
+        board.add(0, playerMini);
+        board.add(1, playerMini);
+        board.add(2, playerMaxi);
+        board.add(3, playerMini);
+        board.add(4, playerMaxi);
+        board.add(5, playerMaxi);
         int result = minimax.optimal();
         assertEquals(6, result);
     }

--- a/src/test/java/MinimaxTest.java
+++ b/src/test/java/MinimaxTest.java
@@ -4,11 +4,11 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class MinimaxTest {
-    Board board;
-    Rules rules;
-    Player playerMaxi;
-    Player playerMini;
-    Minimax minimax;
+    private Board board;
+    private Rules rules;
+    private Player playerMaxi;
+    private Player playerMini;
+    private Minimax minimax;
 
     @Before
     public void setUp() throws Exception {
@@ -50,5 +50,33 @@ public class MinimaxTest {
         board.addMove(8, playerMaxi);
         int result = minimax.minimax(0, false);
         assertEquals(0, result);
+    }
+
+    @Test
+    public void minimaxPlaysForWin() {
+        board.addMove(0, playerMaxi);
+        board.addMove(1, playerMaxi);
+        int result = minimax.optimal();
+        assertEquals(2, result);
+    }
+
+    @Test
+    public void minimaxBlocksOpponentWin() {
+        board.addMove(3, playerMini);
+        board.addMove(4, playerMini);
+        int result = minimax.optimal();
+        assertEquals(5, result);
+    }
+
+    @Test
+    public void minimaxGoesForEarliestWin() {
+        board.addMove(0, playerMini);
+        board.addMove(1, playerMini);
+        board.addMove(2, playerMaxi);
+        board.addMove(3, playerMini);
+        board.addMove(4, playerMaxi);
+        board.addMove(5, playerMaxi);
+        int result = minimax.optimal();
+        assertEquals(6, result);
     }
 }

--- a/src/test/java/MinimaxTest.java
+++ b/src/test/java/MinimaxTest.java
@@ -18,40 +18,6 @@ public class MinimaxTest {
         playerMini = new PlayerHuman("Mini");
         minimax = new Minimax(board, rules, playerMaxi, playerMini);
     }
-
-    @Test
-    public void WinStateReturns10() {
-        board.add(0, playerMaxi);
-        board.add(1, playerMaxi);
-        board.add(2, playerMaxi);
-        int result = minimax.minimax(0, false);
-        assertEquals(10, result);
-    }
-
-    @Test
-    public void LossStateReturnsMinus10() {
-        board.add(0, playerMini);
-        board.add(1, playerMini);
-        board.add(2, playerMini);
-        int result = minimax.minimax(0, false);
-        assertEquals(-10, result);
-    }
-
-    @Test
-    public void DrawReturnsZero() {
-        board.add(0, playerMini);
-        board.add(1, playerMaxi);
-        board.add(2, playerMini);
-        board.add(3, playerMaxi);
-        board.add(4, playerMaxi);
-        board.add(5, playerMini);
-        board.add(6, playerMaxi);
-        board.add(7, playerMini);
-        board.add(8, playerMaxi);
-        int result = minimax.minimax(0, false);
-        assertEquals(0, result);
-    }
-
     @Test
     public void minimaxPlaysForWin() {
         board.add(0, playerMaxi);

--- a/src/test/java/MinimaxTest.java
+++ b/src/test/java/MinimaxTest.java
@@ -1,0 +1,54 @@
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MinimaxTest {
+    Board board;
+    Rules rules;
+    Player playerMaxi;
+    Player playerMini;
+    Minimax minimax;
+
+    @Before
+    public void setUp() throws Exception {
+        board = new Board();
+        rules = new Rules(board);
+        playerMaxi = new PlayerHuman("Maxi");
+        playerMini = new PlayerHuman("Mini");
+        minimax = new Minimax(board, rules, playerMaxi, playerMini);
+    }
+
+    @Test
+    public void WinStateReturns10() {
+        board.addMove(0, playerMaxi);
+        board.addMove(1, playerMaxi);
+        board.addMove(2, playerMaxi);
+        int result = minimax.minimax(0, false);
+        assertEquals(10, result);
+    }
+
+    @Test
+    public void LossStateReturnsMinus10() {
+        board.addMove(0, playerMini);
+        board.addMove(1, playerMini);
+        board.addMove(2, playerMini);
+        int result = minimax.minimax(0, false);
+        assertEquals(-10, result);
+    }
+
+    @Test
+    public void DrawReturnsZero() {
+        board.addMove(0, playerMini);
+        board.addMove(1, playerMaxi);
+        board.addMove(2, playerMini);
+        board.addMove(3, playerMaxi);
+        board.addMove(4, playerMaxi);
+        board.addMove(5, playerMini);
+        board.addMove(6, playerMaxi);
+        board.addMove(7, playerMini);
+        board.addMove(8, playerMaxi);
+        int result = minimax.minimax(0, false);
+        assertEquals(0, result);
+    }
+}

--- a/src/test/java/RulesTest.java
+++ b/src/test/java/RulesTest.java
@@ -45,125 +45,125 @@ public class RulesTest {
 
     @Test
     public void testOccupiedCellIsInvalidMove() {
-        board.addMove(4, playerCross);
+        board.add(4, playerCross);
         assertTrue(rules.isNotValidMove(4));
     }
 
     @Test
     public void checkHorizontalTopIsValidWinCondition() {
-        board.addMove(0, playerCross);
-        board.addMove(1, playerCross);
-        board.addMove(2, playerCross);
+        board.add(0, playerCross);
+        board.add(1, playerCross);
+        board.add(2, playerCross);
         assertTrue(rules.hasWinningMove(playerCross));
 
     }
 
     @Test
     public void checkHorizontalMiddleIsValidWinCondition() {
-        board.addMove(3, playerCross);
-        board.addMove(4, playerCross);
-        board.addMove(5, playerCross);
+        board.add(3, playerCross);
+        board.add(4, playerCross);
+        board.add(5, playerCross);
         assertTrue(rules.hasWinningMove(playerCross));
 
     }
 
     @Test
     public void checkHorizontalBottomIsValidWinCondition() {
-        board.addMove(6, playerCross);
-        board.addMove(7, playerCross);
-        board.addMove(8, playerCross);
+        board.add(6, playerCross);
+        board.add(7, playerCross);
+        board.add(8, playerCross);
         assertTrue(rules.hasWinningMove(playerCross));
 
     }
 
     @Test
     public void checkVerticalLeftIsValidWinCondition() {
-        board.addMove(0, playerCross);
-        board.addMove(3, playerCross);
-        board.addMove(6, playerCross);
+        board.add(0, playerCross);
+        board.add(3, playerCross);
+        board.add(6, playerCross);
         assertTrue(rules.hasWinningMove(playerCross));
     }
 
     @Test
     public void checkVerticalMiddleIsValidWinCondition() {
-        board.addMove(1, playerCross);
-        board.addMove(4, playerCross);
-        board.addMove(7, playerCross);
+        board.add(1, playerCross);
+        board.add(4, playerCross);
+        board.add(7, playerCross);
         assertTrue(rules.hasWinningMove(playerCross));
     }
 
     @Test
     public void checkVerticalRightIsValidWinCondition() {
-        board.addMove(2, playerCross);
-        board.addMove(5, playerCross);
-        board.addMove(8, playerCross);
+        board.add(2, playerCross);
+        board.add(5, playerCross);
+        board.add(8, playerCross);
         assertTrue(rules.hasWinningMove(playerCross));
     }
 
     @Test
     public void checkLeftDiagonalIsValidWinCondition() {
-        board.addMove(0, playerCross);
-        board.addMove(4, playerCross);
-        board.addMove(8, playerCross);
+        board.add(0, playerCross);
+        board.add(4, playerCross);
+        board.add(8, playerCross);
         assertTrue(rules.hasWinningMove(playerCross));
     }
 
     @Test
     public void checkRightDiagonalIsValidWinCondition() {
-        board.addMove(2, playerCross);
-        board.addMove(4, playerCross);
-        board.addMove(6, playerCross);
+        board.add(2, playerCross);
+        board.add(4, playerCross);
+        board.add(6, playerCross);
         assertTrue(rules.hasWinningMove(playerCross));
     }
 
     @Test
     public void checkNoWinningHorizontalMoveReturnsFalse() {
-        board.addMove(0, playerNought);
-        board.addMove(2, playerNought);
-        board.addMove(3, playerCross);
-        board.addMove(4, playerCross);
-        board.addMove(5, playerNought);
-        board.addMove(6, playerNought);
-        board.addMove(7, playerNought);
-        board.addMove(8, playerCross);
+        board.add(0, playerNought);
+        board.add(2, playerNought);
+        board.add(3, playerCross);
+        board.add(4, playerCross);
+        board.add(5, playerNought);
+        board.add(6, playerNought);
+        board.add(7, playerNought);
+        board.add(8, playerCross);
 
         assertFalse(rules.hasWinningMove(playerCross));
     }
 
     @Test
     public void checkThatWinningMovesIsFalseIfOtherPlayerShouldWin() {
-        board.addMove(0, playerNought);
-        board.addMove(1, playerNought);
-        board.addMove(2, playerNought);
+        board.add(0, playerNought);
+        board.add(1, playerNought);
+        board.add(2, playerNought);
 
         assertFalse(rules.hasWinningMove(playerCross));
     }
 
     @Test
     public void checkFullBoardReturnsGameOver() {
-        board.addMove(0, playerNought);
-        board.addMove(1, playerCross);
-        board.addMove(2, playerNought);
-        board.addMove(3, playerCross);
-        board.addMove(4, playerCross);
-        board.addMove(5, playerNought);
-        board.addMove(6, playerNought);
-        board.addMove(7, playerNought);
-        board.addMove(8, playerCross);
+        board.add(0, playerNought);
+        board.add(1, playerCross);
+        board.add(2, playerNought);
+        board.add(3, playerCross);
+        board.add(4, playerCross);
+        board.add(5, playerNought);
+        board.add(6, playerNought);
+        board.add(7, playerNought);
+        board.add(8, playerCross);
 
         assertTrue(rules.gameIsOver());
     }
 
     @Test
     public void checkNotFullBoardDoesNotReturnGameOver() {
-        board.addMove(0, playerNought);
-        board.addMove(1, playerCross);
-        board.addMove(3, playerCross);
-        board.addMove(4, playerCross);
-        board.addMove(5, playerNought);
-        board.addMove(6, playerNought);
-        board.addMove(7, playerNought);
-        board.addMove(8, playerCross);
+        board.add(0, playerNought);
+        board.add(1, playerCross);
+        board.add(3, playerCross);
+        board.add(4, playerCross);
+        board.add(5, playerNought);
+        board.add(6, playerNought);
+        board.add(7, playerNought);
+        board.add(8, playerCross);
 
         assertFalse(rules.gameIsOver());
     }


### PR DESCRIPTION
Adds a CPU (HARD) mode to the game, which implements a Minimax algorithm /w alpha-beta pruning.

Minimax algorithm implemented from Wikipedia's psuedocode so hasn't been refactored, as of yet, to be particularly friendly or perhaps take the most advantage of Java's features. My first attempt was disasterously overengineered and I would be more than happy to show it during the next demo. 

Other additions have been made to the app so that it can support the algorithm, such as Board.remove and Cell.unmark - as the board mutates, moves need to be removed so the board can be returned to its previous state when running the calculations. 

I have no real idea how to test pre-alphabeta and post-alphabeta so would be all ears to suggestions 😄 

Note that, while the algorithm (with alpha beta pruning) doesn't seem to blow the heap, whereas it did before, I still couldn't get it to play the second move in a 4x4 grid after waiting for 28 minutes. So to get support across the whole app we might need to look at memoization/hashing board states? 

 